### PR TITLE
[B] Changed findIndex() with indexOf() for browser support issues

### DIFF
--- a/directive.js
+++ b/directive.js
@@ -31,12 +31,7 @@ const touchs = {
       evt = new Hammer.Manager(el)
     }
     var type = evtType = binding.arg.toLowerCase()
-    var index = -1
-    gestures.findIndex(function(gst, idx){
-      if(gst === type) {
-        index = idx
-      }
-    })
+    var index = gestures.indexOf(type)
     if (index < 0) {
       console.warn('[vue2-touch] event type value is invalid')
       return


### PR DESCRIPTION
`findIndex` is not supported on Internet Explorer (not even v11)